### PR TITLE
Expose the constraint generated in FluentLayout to be accesible from outside world

### DIFF
--- a/Cirrious.FluentLayout/FluentLayout.cs
+++ b/Cirrious.FluentLayout/FluentLayout.cs
@@ -43,6 +43,7 @@ namespace Cirrious.FluentLayouts.Touch
             Priority = (float) UILayoutPriority.Required;
         }
 
+	    public NSLayoutConstraint Constraint { get; set; }
         public UIView View { get; private set; }
         public NSLayoutAttribute Attribute { get; private set; }
         public NSLayoutRelation Relation { get; private set; }
@@ -153,7 +154,7 @@ namespace Cirrious.FluentLayouts.Touch
 
         public IEnumerable<NSLayoutConstraint> ToLayoutConstraints()
         {
-            var constraint = NSLayoutConstraint.Create(
+            Constraint = NSLayoutConstraint.Create(
                 View,
                 Attribute,
                 Relation,
@@ -161,9 +162,9 @@ namespace Cirrious.FluentLayouts.Touch
                 SecondAttribute,
                 Multiplier,
                 Constant);
-            constraint.Priority = Priority;
+			Constraint.Priority = Priority;
 
-            yield return constraint;
+            yield return Constraint;
         }
     }
 }

--- a/Cirrious.FluentLayout/FluentLayout.cs
+++ b/Cirrious.FluentLayout/FluentLayout.cs
@@ -6,7 +6,6 @@
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
 using System;
-using System.Collections.Generic;
 using UIKit;
 using Foundation;
 
@@ -152,19 +151,23 @@ namespace Cirrious.FluentLayouts.Touch
                 throw new Exception("You cannot set the second item in a layout relation more than once");
         }
 
-        public IEnumerable<NSLayoutConstraint> ToLayoutConstraints()
+        public NSLayoutConstraint ToLayoutConstraint()
         {
-            Constraint = NSLayoutConstraint.Create(
-                View,
-                Attribute,
-                Relation,
-                SecondItem,
-                SecondAttribute,
-                Multiplier,
-                Constant);
-			Constraint.Priority = Priority;
+	        if (Constraint == null)
+	        {
+				Constraint = NSLayoutConstraint.Create(
+					View,
+					Attribute,
+					Relation,
+					SecondItem,
+					SecondAttribute,
+					Multiplier,
+					Constant);
 
-            yield return Constraint;
+				Constraint.Priority = Priority;
+			}
+            
+            return Constraint;
         }
     }
 }

--- a/Cirrious.FluentLayout/FluentLayout.cs
+++ b/Cirrious.FluentLayout/FluentLayout.cs
@@ -13,7 +13,7 @@ namespace Cirrious.FluentLayouts.Touch
 {
     public class FluentLayout
     {
-        public FluentLayout(
+	    public FluentLayout(
             UIView view,
             NSLayoutAttribute attribute,
             NSLayoutRelation relation,
@@ -42,8 +42,30 @@ namespace Cirrious.FluentLayouts.Touch
             Priority = (float) UILayoutPriority.Required;
         }
 
-	    public NSLayoutConstraint Constraint { get; set; }
-        public UIView View { get; private set; }
+		private NSLayoutConstraint _constraint;
+		public NSLayoutConstraint Constraint
+	    {
+			get
+			{
+				if (_constraint == null)
+				{
+					_constraint = NSLayoutConstraint.Create(
+						View,
+						Attribute,
+						Relation,
+						SecondItem,
+						SecondAttribute,
+						Multiplier,
+						Constant);
+
+					_constraint.Priority = Priority;
+				}
+
+				return _constraint;
+			}
+	    }
+
+	    public UIView View { get; private set; }
         public NSLayoutAttribute Attribute { get; private set; }
         public NSLayoutRelation Relation { get; private set; }
         public NSObject SecondItem { get; private set; }
@@ -149,25 +171,6 @@ namespace Cirrious.FluentLayouts.Touch
         {
             if (SecondItem != null)
                 throw new Exception("You cannot set the second item in a layout relation more than once");
-        }
-
-        public NSLayoutConstraint ToLayoutConstraint()
-        {
-	        if (Constraint == null)
-	        {
-				Constraint = NSLayoutConstraint.Create(
-					View,
-					Attribute,
-					Relation,
-					SecondItem,
-					SecondAttribute,
-					Multiplier,
-					Constant);
-
-				Constraint.Priority = Priority;
-			}
-            
-            return Constraint;
         }
     }
 }

--- a/Cirrious.FluentLayout/FluentLayoutExtensions.cs
+++ b/Cirrious.FluentLayout/FluentLayoutExtensions.cs
@@ -85,16 +85,16 @@ namespace Cirrious.FluentLayouts.Touch
         {
             view.AddConstraints(fluentLayouts
                                     .Where(fluent => fluent != null)
-                                    .SelectMany(fluent => fluent.ToLayoutConstraints())
+                                    .Select(fluent => fluent.ToLayoutConstraint())
                                     .ToArray());
         }
 
-        public static void AddConstraints(this UIView view, IEnumerable<FluentLayout> fluentLayouts)
-        {
-            view.AddConstraints(fluentLayouts
-                                    .Where(fluent => fluent != null)
-                                    .SelectMany(fluent => fluent.ToLayoutConstraints())
-                                    .ToArray());
-        }
-    }
+		public static void AddConstraints(this UIView view, IEnumerable<FluentLayout> fluentLayouts)
+		{
+			view.AddConstraints(fluentLayouts
+									.Where(fluent => fluent != null)
+									.Select(fluent => fluent.ToLayoutConstraint())
+									.ToArray());
+		}
+	}
 }

--- a/Cirrious.FluentLayout/FluentLayoutExtensions.cs
+++ b/Cirrious.FluentLayout/FluentLayoutExtensions.cs
@@ -85,7 +85,7 @@ namespace Cirrious.FluentLayouts.Touch
         {
             view.AddConstraints(fluentLayouts
                                     .Where(fluent => fluent != null)
-                                    .Select(fluent => fluent.ToLayoutConstraint())
+                                    .Select(fluent => fluent.Constraint)
                                     .ToArray());
         }
 
@@ -93,7 +93,7 @@ namespace Cirrious.FluentLayouts.Touch
 		{
 			view.AddConstraints(fluentLayouts
 									.Where(fluent => fluent != null)
-									.Select(fluent => fluent.ToLayoutConstraint())
+									.Select(fluent => fluent.Constraint)
 									.ToArray());
 		}
 	}


### PR DESCRIPTION
With this simple change we gain access to the NSLayoutConstraint. This is needed to animate constraints or any other operation. Please, see my comment here: https://github.com/slodge/Cirrious.FluentLayout/issues/18

This is how I´m using the added property:

````
_monsterOffVerticalLayout = _monsterOff.Above(ground);

View.AddConstraints(
    ...
    _monsterOffVerticalLayout,
    ...
);

_monsterOffVerticalConstraint = _monsterOffVerticalLayout.Constraint;
_monsterOffVerticalConstraint.Constant = 250 * Multiplier;
UIView.Animate(0.2, 0.0, UIViewAnimationOptions.CurveEaseIn, () => View.LayoutIfNeeded(), () => {});