### PR TITLE
AdvancedVerticalStackPanelConstraints UIView extension

### DIFF
--- a/Cirrious.FluentLayout/AdvancedFluentLayoutExtensions.cs
+++ b/Cirrious.FluentLayout/AdvancedFluentLayoutExtensions.cs
@@ -123,25 +123,11 @@ namespace Cirrious.FluentLayouts.Touch
         public static IEnumerable<FluentLayout> VerticalStackPanelConstraints(this UIView parentView, Margins margins,
                                                                               params UIView[] views)
         {
-            margins = margins ?? new Margins();
-
-            UIView previous = null;
-            foreach (var view in views)
-            {
-                yield return view.Left().EqualTo().LeftOf(parentView).Plus(margins.Left);
-                yield return view.Width().EqualTo().WidthOf(parentView).Minus(margins.Right + margins.Left);
-                if (previous != null)
-                    yield return view.Top().EqualTo().BottomOf(previous).Plus(margins.VSpacing);
-                else
-                    yield return view.Top().EqualTo().TopOf(parentView).Plus(margins.Top);
-                previous = view;
-            }
-            if (parentView is UIScrollView)
-                yield return previous.Bottom().EqualTo().BottomOf(parentView).Minus(margins.Bottom);
+	        return AdvancedVerticalStackPanelConstraints(parentView, margins, views: views);
 		}
 
 		/// <summary>
-		/// Vertical stack panel constraints with support for children idependent left, right and top margins
+		/// Vertical stack panel constraints with support for children independent left, right and top margins
 		/// and a multiplier factor for all margins applied. The multiplier can be useful when dealing with ipad screens.
 		/// Example:
 		/// 

--- a/Cirrious.FluentLayout/AdvancedFluentLayoutExtensions.cs
+++ b/Cirrious.FluentLayout/AdvancedFluentLayoutExtensions.cs
@@ -138,6 +138,54 @@ namespace Cirrious.FluentLayouts.Touch
             }
             if (parentView is UIScrollView)
                 yield return previous.Bottom().EqualTo().BottomOf(parentView).Minus(margins.Bottom);
-        }
-    }
+		}
+
+		/// <summary>
+		/// Vertical stack panel constraints with support for children idependent left, right and top margins
+		/// and a multiplier factor for all margins applied. The multiplier can be useful when dealing with ipad screens.
+		/// Example:
+		/// 
+		/// scrollView.AddConstraints(scrollView.AdvancedVerticalStackPanelConstraints(null,
+		///      childrenLeftMargins: new float[] { 15, 0, 15, 0, 0, 15 },
+		///      childrenTopMargins: new float[] { 15, 5, 15, 5, 8, 15, 22, 8, 8, 28, 28 },
+		///      marginMultiplier: 2f,
+		///      views: scrollView.Subviews)
+		/// );
+		/// </summary>
+		public static IEnumerable<FluentLayout> AdvancedVerticalStackPanelConstraints(this UIView parentView,
+			Margins margins,
+			float[] childrenLeftMargins = null,
+			float[] childrenTopMargins = null,
+			float[] childrenRightMargins = null,
+			float marginMultiplier = 1,
+			params UIView[] views)
+		{
+			margins = margins ?? new Margins();
+
+			var count = views.Length;
+			for (var i = 0; i < count; i++)
+			{
+				float childLeftMargin;
+				childrenLeftMargins.TryGetElement(i, out childLeftMargin);
+				var marginLeft = Math.Max(margins.Left, childLeftMargin) * marginMultiplier;
+				yield return views[i].Left().EqualTo().LeftOf(parentView).Plus(marginLeft);
+
+				float childRightMargin;
+				childrenRightMargins.TryGetElement(i, out childRightMargin);
+				var marginRight = Math.Max(margins.Right, childRightMargin) * marginMultiplier;
+				yield return views[i].Width().EqualTo().WidthOf(parentView).Minus(marginRight + marginLeft);
+
+				float childTopMargin;
+				childrenTopMargins.TryGetElement(i, out childTopMargin);
+
+				if (i == 0)
+					yield return views[i].Top().EqualTo().TopOf(parentView).Plus(Math.Max(margins.Top, childTopMargin) * marginMultiplier);
+				else
+					yield return views[i].Top().EqualTo().BottomOf(views[i - 1]).Plus(Math.Max(margins.VSpacing, childTopMargin) * marginMultiplier);
+			}
+
+			if (parentView is UIScrollView)
+				yield return views[views.Length - 1].Bottom().EqualTo().BottomOf(parentView).Minus(margins.Bottom * marginMultiplier);
+		}
+	}
 }

--- a/Cirrious.FluentLayout/ArrayExtensions.cs
+++ b/Cirrious.FluentLayout/ArrayExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace Cirrious.FluentLayouts.Touch
+{
+	public static class ArrayExtensions
+	{
+		public static bool TryGetElement<T>(this T[] array, int index, out T element)
+		{
+			if (array == null)
+			{
+				element = default(T);
+				return false;
+			}
+
+			if (index < array.Length)
+			{
+				element = array[index];
+				return true;
+			}
+
+			element = default(T);
+			return false;
+		}
+	}
+}

--- a/Cirrious.FluentLayout/Cirrious.FluentLayouts.Touch.csproj
+++ b/Cirrious.FluentLayout/Cirrious.FluentLayouts.Touch.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AdvancedFluentLayoutExtensions.cs" />
+    <Compile Include="ArrayExtensions.cs" />
     <Compile Include="FluentLayout.cs" />
     <Compile Include="FluentLayoutExtensions.cs" />
     <Compile Include="Margins.cs" />

--- a/QuickLayout.Core/QuickLayout.Core.csproj
+++ b/QuickLayout.Core/QuickLayout.Core.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Services\CalculationService.cs" />
     <Compile Include="Services\ICalculationService.cs" />
     <Compile Include="ViewModels\BaseDetailsViewModel.cs" />
+    <Compile Include="ViewModels\DetailsMarginsViewModel.cs" />
     <Compile Include="ViewModels\DetailsViewModel.cs" />
     <Compile Include="ViewModels\FirstViewModel.cs" />
     <Compile Include="ViewModels\FormGridViewModel.cs" />

--- a/QuickLayout.Core/ViewModels/DetailsMarginsViewModel.cs
+++ b/QuickLayout.Core/ViewModels/DetailsMarginsViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace QuickLayout.Core.ViewModels
+{
+	public class DetailsMarginsViewModel : BaseDetailsViewModel
+	{
+	}
+}

--- a/QuickLayout.Core/ViewModels/FirstViewModel.cs
+++ b/QuickLayout.Core/ViewModels/FirstViewModel.cs
@@ -10,7 +10,12 @@ namespace QuickLayout.Core.ViewModels
             ShowViewModel<DetailsViewModel>();
         }
 
-        public void GoForm()
+	    public void GoDetailsWithMargins()
+	    {
+		    ShowViewModel<DetailsMarginsViewModel>();
+	    }
+
+		public void GoForm()
         {
             ShowViewModel<FormViewModel>();
         }

--- a/QuickLayout.Touch/QuickLayout.Touch.csproj
+++ b/QuickLayout.Touch/QuickLayout.Touch.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
     <Compile Include="Setup.cs" />
+    <Compile Include="Views\DetailsMarginsView.cs" />
     <Compile Include="Views\DetailsView.cs" />
     <Compile Include="Views\FirstView.cs" />
     <Compile Include="Views\FormGridView.cs" />

--- a/QuickLayout.Touch/Views/DetailsMarginsView.cs
+++ b/QuickLayout.Touch/Views/DetailsMarginsView.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Cirrious.FluentLayouts.Touch;
+using Cirrious.MvvmCross.Binding.BindingContext;
+using Cirrious.MvvmCross.Touch.Views;
+using UIKit;
+using Foundation;
+using QuickLayout.Core.ViewModels;
+using ObjCRuntime;
+using Cirrious.FluentLayouts;
+
+namespace QuickLayout.Touch.Views
+{
+    [Register("DetailsMarginsView")]
+    public class DetailsMarginsView : MvxViewController
+    {
+        public override void ViewDidLoad()
+        {
+            var scrollView = new UIScrollView()
+                {
+                    BackgroundColor = UIColor.White,
+                    ShowsHorizontalScrollIndicator = false, 
+                    AutoresizingMask = UIViewAutoresizing.FlexibleHeight,
+                };
+            View = scrollView;
+            scrollView.TranslatesAutoresizingMaskIntoConstraints = true;
+            base.ViewDidLoad();
+
+            // ios7 layout
+            if (RespondsToSelector(new Selector("edgesForExtendedLayout")))
+                EdgesForExtendedLayout = UIRectEdge.None;
+
+            var set = this.CreateBindingSet<DetailsMarginsView, DetailsViewModel>();
+
+			var topMargins = new List<float>();
+			var leftMargins = new List<float>();
+			var rightMargins = new List<float>();
+
+            foreach (var propertyInfo in typeof(DetailsViewModel).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (propertyInfo.PropertyType != typeof (string))
+                    continue;
+
+				topMargins.Add(20);
+				leftMargins.Add(0);
+				rightMargins.Add(0);
+                var introLabel = new UILabel
+                {
+                    Text = propertyInfo.Name + ":",
+                    TranslatesAutoresizingMaskIntoConstraints = false,
+                };
+                Add(introLabel);
+
+				topMargins.Add(0);
+				leftMargins.Add(25);
+				rightMargins.Add(25);
+				var textField = new UITextField
+                    {
+                        BorderStyle = UITextBorderStyle.RoundedRect,
+                        TranslatesAutoresizingMaskIntoConstraints = false,
+                        BackgroundColor = UIColor.LightGray
+                    };
+                Add(textField);
+
+				topMargins.Add(0);
+				leftMargins.Add(40);
+				rightMargins.Add(40);
+				var label = new UILabel
+                {
+                    TranslatesAutoresizingMaskIntoConstraints = false,
+                    BackgroundColor = UIColor.Yellow,
+					TextAlignment = UITextAlignment.Center
+                };
+                Add(label);
+
+                set.Bind(label).To(propertyInfo.Name);
+                set.Bind(textField).To(propertyInfo.Name);
+            }
+            set.Apply();
+
+			var marginMultiplier = UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad ? 2 : 1;
+
+			var constraints = View.AdvancedVerticalStackPanelConstraints(
+                                                   new Margins(20, 10, 20, 10, 5, 5),
+												   leftMargins.ToArray(),
+												   topMargins.ToArray(),
+												   rightMargins.ToArray(),
+												   marginMultiplier,
+                                                   View.Subviews);
+            View.AddConstraints(constraints);
+        }
+    }
+}

--- a/QuickLayout.Touch/Views/FirstView.cs
+++ b/QuickLayout.Touch/Views/FirstView.cs
@@ -33,7 +33,11 @@ namespace QuickLayout.Touch.Views
             buttonD.SetTitle("Details", UIControlState.Normal);
             Add(buttonD);
 
-            var buttonS = new UIButton(UIButtonType.RoundedRect);
+			var buttonD2 = new UIButton(UIButtonType.RoundedRect);
+			buttonD2.SetTitle("Details with margins", UIControlState.Normal);
+			Add(buttonD2);
+
+			var buttonS = new UIButton(UIButtonType.RoundedRect);
             buttonS.SetTitle("Search", UIControlState.Normal);
             Add(buttonS);
 
@@ -47,6 +51,7 @@ namespace QuickLayout.Touch.Views
             set.Bind(buttonF).To("GoForm");
             set.Bind(buttonFG).To("GoFormGrid");
             set.Bind(buttonD).To("GoDetails");
+	        set.Bind(buttonD2).To("GoDetailsWithMargins");
             set.Bind(buttonS).To("GoSearch");
             set.Bind(buttonT).To("GoTip");
             set.Apply();


### PR DESCRIPTION
Vertical stack panel constraints with support for children independent left, right and top margins
and a multiplier factor for all margins applied. The multiplier can be useful when dealing with ipad screens. 
It will respect the global margins specified in the Margins object.
The children specific margin will only be applied when it´s bigger than the global margin.

This is tested and it´s been very handy for the app I´m doing.
Example:
```
scrollView.AddConstraints(scrollView.AdvancedVerticalStackPanelConstraints(null,
     childrenLeftMargins: new float[] { 15, 0, 15, 0, 0, 15 },
     childrenTopMargins: new float[] { 15, 5, 15, 5, 8, 15, 22, 8, 8, 28, 28 },
     marginMultiplier: 2f,
     views: scrollView.Subviews)
```